### PR TITLE
Improve health monitoring and utility functions

### DIFF
--- a/src/Monitor/HealthMonitor.php
+++ b/src/Monitor/HealthMonitor.php
@@ -75,11 +75,15 @@ class HealthMonitor
                     return;
                 }
 
+                $binLogCurrentCache = $this->binLogCurrentSnapshot->get();
+
                 if (
-                    $this->binLogCurrentSnapshot->get() instanceof BinLogCurrent
-                    && $this->binLogCurrentSnapshot->get()->getBinLogPosition() == $this->binLogCurrent->getBinLogPosition()
+                    $binLogCurrentCache instanceof BinLogCurrent
+                    && $binLogCurrentCache->getBinLogPosition() == $this->binLogCurrent->getBinLogPosition()
                 ) {
-                    $this->container->get(EventDispatcherInterface::class)?->dispatch(new OnReplicationStop($this->connection, $this->binLogCurrent));
+                    if ($this->container->has(EventDispatcherInterface::class)) {
+                        $this->container->get(EventDispatcherInterface::class)?->dispatch(new OnReplicationStop($this->connection, $this->binLogCurrent));
+                    }
                 }
 
                 $this->binLogCurrentSnapshot->set($this->binLogCurrent);

--- a/src/Util.php
+++ b/src/Util.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  */
 namespace FriendsOfHyperf\Trigger;
 
+use RuntimeException;
+
 class Util
 {
     /**
@@ -29,6 +31,6 @@ class Util
             return $ip;
         }
 
-        throw new \RuntimeException('Can not get the internal IP.');
+        throw new RuntimeException('Can not get the internal IP.');
     }
 }


### PR DESCRIPTION
- Add a check to ensure EventDispatcherInterface is present before dispatching the OnReplicationStop event
- Change usage of binLogCurrentSnapshot to `$binLogCurrentCache` for better readability
- Ensure binLogCurrentSnapshot and binLogCurrent have the same binLogPosition before dispatching the OnReplicationStop event
- Add `use RuntimeException` statement
- Change `\RuntimeException` to `RuntimeException` in the `getInternalIp